### PR TITLE
Added a method to handle jobs when a lock was already acquired

### DIFF
--- a/lib/resque/plugins/lock_timeout.rb
+++ b/lib/resque/plugins/lock_timeout.rb
@@ -123,10 +123,14 @@ module Resque
         Resque.redis.exists(redis_lock_key(*args))
       end
 
+      # Override this method to handle the job if lock exists
+      def abort_lock(*args)
+      end
+
       # Where the magic happens.
       def around_perform_lock(*args)
         # Abort if another job holds the lock.
-        return unless lock_until = acquire_lock!(*args)
+        return abort_lock(*args) unless lock_until = acquire_lock!(*args)
 
         begin
           yield


### PR DESCRIPTION
Added a method to handle jobs when a lock was already acquired.
This would allow, for example, to override the abort_lock method to requeue messages that were not processed (avoiding to lose messages from the queue)
