### PR TITLE
This commit allows one to override the redis connection used to store the locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,24 @@ repo_id.
 
 It's lock key would be: `resque-lock-timeout:UpdateNetworkGraph`.
 
+### Redis Connection Used for Locking
+
+By default all locks are stored via Resque's redis connection. If you wish to
+change this you may override `lock_redis`.
+
+    class UpdateNetworkGraph
+      extend Resque::Plugins::LockTimeout
+      @queue = :network_graph
+
+      def self.lock_redis
+        @lock_redis ||= Redis.new
+      end
+
+      def self.perform(repo_id)
+        heavy_lifting
+      end
+    end
+
 ### Callbacks
 
 Several callbacks are available to override and implement your own logic, e.g.

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -60,3 +60,25 @@ class ExpireBeforeReleaseJob
     $lock_expired = true
   end
 end
+
+class SpecificRedisJob
+  extend Resque::Plugins::LockTimeout
+  @queue = :test
+
+  def self.lock_redis
+    @redis
+  end
+
+  def self.lock_redis=(redis)
+    @redis = redis
+  end
+
+  def self.redis_lock_key
+    'specific_redis'
+  end
+
+  def self.perform
+    $success += 1
+    sleep 0.2
+  end
+end


### PR DESCRIPTION
The big win is this lets you easily pick which redis server the locks are written to. In particular, if you have a setup where specific jobs go to specific redises, this makes it much easier to keep the locks with those workers.

It also has the side effect of allowing you to not namespace the lock names if you desire them not to be, since you don't have to use a Redis::Namespace for storing the locks.

I've added a test and updated the readme accordingly.

Please let me know if you have any issues with this, otherwise it'd be awesome if we could get a new version of the gem released with this patch. I'm about to monkey patch this into our rails app (groupon.com), but would prefer that to be short-lived.
