### PR TITLE
README: clarify identifier section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The above modification will ensure only one job of class
 UpdateNetworkGraph is running at a time, regardless of the
 repo_id.
 
-Its lock key would be: `lock:UpdateNetworkGraph`.
+Its lock key would be: `lock:UpdateNetworkGraph` (the `:<identifier>` part is left out if the identifier is `nil`).
 
 You can define the entire key by overriding `redis_lock_key`:
 


### PR DESCRIPTION
The "resque-lock-timeout" prefix is not actually in use. Example of "redis_lock_key".
