### PR TITLE
Loner job with a timeout can't be enqueue again if it completes after timeout expiration

### DIFF
--- a/test/lock_test.rb
+++ b/test/lock_test.rb
@@ -192,4 +192,14 @@ class LockTest < MiniTest::Unit::TestCase
     assert_equal 1, $success, 'One job should increment success'
   end
 
+  def test_loner_job_should_get_enqueued_if_timeout_expired
+    Resque.enqueue(LonelyTimeoutExpiringJob)
+    thread = Thread.new { @worker.process }
+
+    sleep 2.1 # Wait for job to finish.
+
+    Resque.enqueue(LonelyTimeoutExpiringJob)
+    assert_equal 1, Resque.size(:test), "Should be able to enqueue a loner job if one previously finished after the timeout"
+  end
+
 end

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -146,3 +146,15 @@ class LonelyTimeoutJob
     $enqueue_failed += 1
   end
 end
+
+# This job won't complete before it's timeout
+class LonelyTimeoutExpiringJob
+  extend Resque::Plugins::LockTimeout
+  @queue = :test
+  @loner = true
+  @lock_timeout = 1
+
+  def self.perform
+    sleep 2
+  end
+end


### PR DESCRIPTION
I hit this issue in production.

Basically, for a loner job with a timeout of 60 seconds, if the job takes more than 60 seconds to complete, it cannot be enqueued again! I had to manually clear up the locks to unblock some of our users.

Here is a quick patch to make sure that a loner job can be enqueued event if a previous instance of the job did not complete before its timeout.
