### PR TITLE
Update Resque dependency to 1.22.0. 

### DIFF
--- a/resque-lock-timeout.gemspec
+++ b/resque-lock-timeout.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob('lib/**/*')
   s.files            += Dir.glob('test/**/*')
 
-  s.add_dependency('resque', '>= 1.8.0')
+  s.add_dependency('resque', '>= 1.22.0')
   s.add_development_dependency('rake')
   s.add_development_dependency('minitest')
   s.add_development_dependency('json')

--- a/test/lock_test.rb
+++ b/test/lock_test.rb
@@ -202,4 +202,15 @@ class LockTest < MiniTest::Unit::TestCase
     assert_equal 1, Resque.size(:test), "Should be able to enqueue a loner job if one previously finished after the timeout"
   end
 
+  def test_loner_job_should_get_enqueued_if_previous_inline_job_finished
+    Resque.inline = true
+    Resque.enqueue(LonelyJob)
+    Resque.inline = false
+
+    sleep 0.5
+
+    assert_equal 0, Resque.size(:test), "Nothing should be in the queue"
+    Resque.enqueue(LonelyJob)
+    assert_equal 1, Resque.size(:test), "Should have enqueued the job"
+  end
 end


### PR DESCRIPTION
Loner feature needs it to work when running Resque inline. In that Resque version, around_perform_hooks are enabled for inline mode. Before, an inline job would run and leave its lock behind, preventing new jobs with the same identifier from being enqueued.

Add a test that fails with an older version of Resque and passes with 1.22.0.
