### PR TITLE
Add enqueued? and loner_locked? helper methods that work like locked?

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ using job arguments. e.g.
 ### Helper Methods
 
 * `locked?` - checks if the lock is currently held.
+* `enqueued?` - checks if the loner lock is currently held.
+* `loner_locked?` - checks if the job is either enqueued (if a loner) or locked (any job).
 * `refresh_lock!` - Refresh the lock, useful for jobs that are taking longer
     then usual but your okay with them holding on to the lock a little longer.
 


### PR DESCRIPTION
We were using resque-loner and took it out to use resque-lock-timeout's loner functionality instead. Our app didn't enqueue jobs until after the DB transaction has committed, and there is the locked? method but no analog to check if a enqueue will fail because of a loner lock.

This PR adds an enqueued? method that works like resque-loner's Resque.enqueued? and a loner_locked? method that returns true if either lock exists.
