### PR TITLE
Fix silent exceptions when lock timeout expires before exception raised.

### DIFF
--- a/lib/resque/plugins/lock_timeout.rb
+++ b/lib/resque/plugins/lock_timeout.rb
@@ -287,15 +287,13 @@ module Resque
         ensure
           # Release the lock on success and error. Unless a lock_timeout is
           # used, then we need to be more careful before releasing the lock.
-          unless lock_until === true
-            now = Time.now.to_i
-            if lock_until < now
-              # Eeek! Lock expired before perform finished. Trigger callback.
-              lock_expired_before_release(*args)
-              return # dont relase lock.
-            end
+          now = Time.now.to_i
+          if lock_until != true and lock_until < now
+            # Eeek! Lock expired before perform finished. Trigger callback.
+            lock_expired_before_release(*args)
+          else
+            release_lock!(*args)
           end
-          release_lock!(*args)
         end
       end
 

--- a/test/lock_test.rb
+++ b/test/lock_test.rb
@@ -225,4 +225,10 @@ class LockTest < Minitest::Test
     Resque.enqueue(LonelyJob)
     assert_equal 1, Resque.size(:test), "Should have enqueued the job"
   end
+
+  def test_exceptions_in_job_after_timeout_should_be_marked_as_failure
+    Resque.enqueue(FailingAfterTimeoutJob)
+    @worker.process
+    assert_equal 1, Resque::Failure.count, "Should have been marked as failure"
+  end
 end

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -158,3 +158,15 @@ class LonelyTimeoutExpiringJob
     sleep 2
   end
 end
+
+# Job that raises an error after its timeout.
+class FailingAfterTimeoutJob
+  extend Resque::Plugins::LockTimeout
+  @queue = :test
+  @lock_timeout = 1
+
+  def self.perform
+    sleep 2
+    raise
+  end
+end


### PR DESCRIPTION
The `return` in the ensure block of the `around_perform_lock` method causes exceptions not to be raised and flagged as failures when exceptions are raised after the lock timeout. This PR fixes this issue by not invoking `return`.