### PR TITLE
Explicitly remove lock upon job's dirty exit using worker's on failure hook

### DIFF
--- a/lib/resque/plugins/lock_timeout.rb
+++ b/lib/resque/plugins/lock_timeout.rb
@@ -297,7 +297,12 @@ module Resque
         end
       end
 
+      def on_failure_lock(exception, *args)
+        # In case of a DirtyExit, the ensure block of the around hook is not called
+        if exception.is_a?(Resque::DirtyExit)
+          release_lock!(*args)
+        end
+      end
     end
-
   end
 end

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -38,6 +38,16 @@ class FailingFastJob
   end
 end
 
+# Job that fails with a SIGKILL
+class FailingKilledJob
+  extend Resque::Plugins::LockTimeout
+  @queue = :test
+
+  def self.perform
+    Process.kill("KILL", Process.pid)
+  end
+end
+
 # Job that enables the timeout algorithm.
 class SlowWithTimeoutJob
   extend Resque::Plugins::LockTimeout


### PR DESCRIPTION
Fixes #26, inspired by lantins/resque-retry#61